### PR TITLE
dependency upgrades and option to save parameters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       run: |
         dotnet publish -o bin\publish -c Debug -r win-x64
     - name: artifact
-      uses: actions/upload-artifact@v1.0.0
+      uses: actions/upload-artifact@v4.0.0
       with:
         # Artifact name
         name: WSLAttachSwitch

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     - name: dotnet publish
       shell: cmd
       run: |
-        dotnet publish -o bin\publish -c Debug -r win-x64
+        dotnet publish -o bin\publish -c Debug -r win-x64 .\WSLAttachSwitch.csproj
     - name: artifact
       uses: actions/upload-artifact@v4.0.0
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v1
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 9.0.x
     - name: dotnet publish
       shell: cmd
       run: |

--- a/ComputeService/ComputeSystem.cs
+++ b/ComputeService/ComputeSystem.cs
@@ -71,7 +71,7 @@ namespace WSLAttachSwitch.ComputeService
             return doc.RootElement;
         }
 
-        public string Modify(string resourcePath, ModifyRequestType requestType, JsonObject settings, JsonObject guestRequest)
+        public string Modify(string resourcePath, ModifyRequestType requestType, JsonObject settings, JsonObject? guestRequest)
         {
             var request = new JsonObject
             {

--- a/JsonElementHelper.cs
+++ b/JsonElementHelper.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text.Json;
+
+namespace WSLAttachSwitch
+{
+    internal static class JsonElementHelper
+    {
+
+        public static JsonElement GetPropertyCaseInsensitive(this JsonElement jsonElement, string propertyName)
+        {
+            foreach (JsonProperty property in jsonElement.EnumerateObject())
+            {
+                if (property.Name.Equals(propertyName, StringComparison.InvariantCultureIgnoreCase))
+                {
+                    return property.Value;
+                }
+            }
+
+            throw new KeyNotFoundException($"Property '{propertyName}' not found in JSON element.");
+        }
+    }
+}

--- a/JsonElementHelper.cs
+++ b/JsonElementHelper.cs
@@ -9,13 +9,22 @@ namespace WSLAttachSwitch
 
         public static JsonElement GetPropertyCaseInsensitive(this JsonElement jsonElement, string propertyName)
         {
-            foreach (JsonProperty property in jsonElement.EnumerateObject())
+            if (jsonElement.TryGetProperty(propertyName, out JsonElement jsonProperty))
             {
-                if (property.Name.Equals(propertyName, StringComparison.InvariantCultureIgnoreCase))
+                return jsonProperty;
+            }
+            else
+            {
+                //On some machines (not sure depending on what factor exactly), the property names within the Hyper-V API response come entirely upper cased (opposed to the provided schema), therefore the fallback here:
+                foreach (JsonProperty property in jsonElement.EnumerateObject())
                 {
-                    return property.Value;
+                    if (property.Name.Equals(propertyName, StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        return property.Value;
+                    }
                 }
             }
+
 
             throw new KeyNotFoundException($"Property '{propertyName}' not found in JSON element.");
         }

--- a/ParamService.cs
+++ b/ParamService.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace WSLAttachSwitch
+{
+    //This is required due to AOT compilation and assembly trimming:
+    [JsonSerializable(typeof(Params))]
+    [JsonSourceGenerationOptions(WriteIndented = true)]
+    public partial class JsonContext : JsonSerializerContext
+    {
+    }
+
+    public record Params(string Network, string? MacAddress, int? Vlan)
+    {
+        public override string ToString()
+        {
+            return $"Network: {Network}, MAC: {MacAddress}, VLAN: {Vlan}";
+        }
+
+        public bool AreValid()
+        {
+            return !string.IsNullOrEmpty(Network);
+        }
+    }
+
+    internal class ParamService
+    {
+        private static readonly string AppFolder = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),"WSLAttachSwitch");
+        private static readonly string ParamsFile = Path.Combine(AppFolder, "params.json");
+
+        public static bool Save(Params parameters)
+        {
+            try
+            {
+                Directory.CreateDirectory(AppFolder);
+                string json = JsonSerializer.Serialize(parameters, JsonContext.Default.Params);
+                File.WriteAllText(ParamsFile, json);
+                return true;
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public static bool TryLoad(out Params parameters)
+        {
+            try
+            {
+                if (File.Exists(ParamsFile))
+                {
+                    var json = File.ReadAllText(ParamsFile);
+                    parameters = JsonSerializer.Deserialize<Params>(json, JsonContext.Default.Params) ?? new Params(string.Empty, null, null);
+                    Console.WriteLine($"Loaded parameters: {parameters}");
+                    return true;
+                }
+            }
+            catch (Exception ex)
+            {
+                Console.Error.WriteLine($"Error while loading saved parameters: {ex.Message}");
+            }
+
+            parameters = new Params(string.Empty, null, null);
+            return false;
+        }
+
+        public static bool GetOrLoadParams(string? network, string? macAddress, int? vlanId, out Params paramsToBeUsed)
+        {
+            Params passedParams = new(network ?? string.Empty, macAddress, vlanId);
+            if (passedParams.AreValid())
+            {
+                paramsToBeUsed = passedParams;
+                return true;
+            }
+            else
+            {
+                if (TryLoad(out Params? savedParams) && savedParams.AreValid())
+                {
+                    paramsToBeUsed = savedParams;
+                    return true;
+                }
+                else
+                {
+                    Console.Error.WriteLine("No network specified and no saved parameters found. Use --network option to specify a network.");
+                    paramsToBeUsed = passedParams;
+                    return false;
+                }
+            }
+        }
+    }
+}

--- a/Program.cs
+++ b/Program.cs
@@ -231,7 +231,7 @@ namespace WSLAttachSwitch
                 }
             };
 
-            Option<bool?> saveConfigOption= new("--save-config")
+            Option<bool?> saveConfigOption= new("--save-params")
             {
                 Description = "Controls explicitly, if the chosen parameters are going to be saved (will be used when program is launched without args)",
                 Required = false,
@@ -263,11 +263,15 @@ namespace WSLAttachSwitch
                     exitCode = Attach(paramsToBeUsed.Network, paramsToBeUsed.MacAddress, paramsToBeUsed.Vlan) ? 0 : 1;
                 }                
 
-                bool saveConfig = parseResult.GetValue<bool?>(saveConfigOption) != false; //Save the config if the option is true or not specified
+                bool saveConfig = parseResult.GetValue<bool?>(saveConfigOption) == true;
                 Params paramsToSave = new Params(network ?? string.Empty, macAddress, vlanId);
                 if (saveConfig && paramsToSave.AreValid()) //Don't save, if the parameters are not valid (-> if no network name was provided)
                 {
                     ParamService.Save(paramsToSave);
+                }
+                else
+                {
+                    Console.Error.WriteLine("Didn't save the passed parameters because they are invalid!");
                 }
             });
 

--- a/Program.cs
+++ b/Program.cs
@@ -231,7 +231,7 @@ namespace WSLAttachSwitch
                 }
             };
 
-            Option<bool?> saveConfigOption= new("--save-params")
+            Option<bool?> saveConfigOption= new("--save-params", "-s")
             {
                 Description = "Controls explicitly, if the chosen parameters are going to be saved (will be used when program is launched without args)",
                 Required = false,

--- a/Program.cs
+++ b/Program.cs
@@ -17,7 +17,7 @@ namespace WSLAttachSwitch
             foreach (var id in networks)
             {
                 var network = ComputeNetwork.Open(id);
-                if (name.Equals(network.QueryProperites().GetProperty("Name").GetString(), StringComparison.OrdinalIgnoreCase))
+                if (name.Equals(network.QueryProperites().GetPropertyCaseInsensitive("Name").GetString(), StringComparison.OrdinalIgnoreCase))
                 {
                     return network;
                 }
@@ -49,7 +49,7 @@ namespace WSLAttachSwitch
                     Console.Error.WriteLine("Can't find unique WSL VM. Is WSL2 running?");
                     return false;
                 }
-                string? systemid = systems[0].GetProperty("Id").GetString();
+                string? systemid = systems[0].GetPropertyCaseInsensitive("Id").GetString();
                 if (string.IsNullOrEmpty(systemid))
                 {
                     Console.Error.WriteLine("Can't detect ID of WSL2 VM.");
@@ -66,7 +66,7 @@ namespace WSLAttachSwitch
                 {
                     network = FindNetworkByName(networkName);
                     JsonElement netprops = network.QueryProperites();
-                    string? networkId = netprops.GetProperty("Id").GetString();
+                    string? networkId = netprops.GetPropertyCaseInsensitive("Id").GetString();
                     if (string.IsNullOrEmpty(networkId))
                     {
                         Console.Error.WriteLine("Can't detect network ID.");

--- a/Program.cs
+++ b/Program.cs
@@ -233,7 +233,7 @@ namespace WSLAttachSwitch
 
             Option<bool?> saveConfigOption= new("--save-params", "-s")
             {
-                Description = "Controls explicitly, if the chosen parameters are going to be saved (will be used when program is launched without args)",
+                Description = "Causes the provided parameters to be persisted (will be used when program is launched without a network given)",
                 Required = false,
                 Arity = ArgumentArity.ZeroOrOne
             };
@@ -268,10 +268,7 @@ namespace WSLAttachSwitch
                 if (saveConfig && paramsToSave.AreValid()) //Don't save, if the parameters are not valid (-> if no network name was provided)
                 {
                     ParamService.Save(paramsToSave);
-                }
-                else
-                {
-                    Console.Error.WriteLine("Didn't save the passed parameters because they are invalid!");
+                    Console.WriteLine("Parameters saved, will be reused when the tool is invoked without a network provided.");
                 }
             });
 

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,7 @@
+{
+  "profiles": {
+    "WSLAttachSwitch": {
+      "commandName": "Project"
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ then it is officially available on WSL2 preview, check [this comment](https://gi
 
 ## Arguments
 ```
---mac <mac>     If specified, use this physical address for the virtual interface instead of random one.
---vlan <vlan>   If specified, enable VLAN filtering with this VLAN ID for the virtual interface.
+--mac <mac>                 If specified, use this physical address for the virtual interface instead of random one.
+--vlan <vlan>               If specified, enable VLAN filtering with this VLAN ID for the virtual interface.
+--save-params <true/false>  If specified and set to true, will save the passed parameters to %appdata%\WSLAttachSwitch\params.json (will be read from there if no network name is passed when the tool is launched afterwards)
 ```
 
 ## Example
@@ -50,6 +51,8 @@ WSLAttachSwitch.exe "New Virtual Switch"
 WSLAttachSwitch.exe "New Virtual Switch" --mac 00-11-45-14-19-19
 WSLAttachSwitch.exe --mac 00:11:45:14:19:19 "New Virtual Switch"
 WSLAttachSwitch.exe --mac 0011.4514.1919 "New Virtual Switch" --vlan 2
+WSLAttachSwitch.exe "New Virtual Switch" --save-params true
+WSLAttachSwitch.exe #If the tool was previously invoked with --save-params true, then it will re-use the parameters from that invocation
 ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ then it is officially available on WSL2 preview, check [this comment](https://gi
 
 ## Arguments
 ```
---mac <mac>                 If specified, use this physical address for the virtual interface instead of random one.
---vlan <vlan>               If specified, enable VLAN filtering with this VLAN ID for the virtual interface.
---save-params <true/false>  If specified and set to true, will save the passed parameters to %appdata%\WSLAttachSwitch\params.json (will be read from there if no network name is passed when the tool is launched afterwards)
+--mac <mac>     If specified, use this physical address for the virtual interface instead of random one.
+--vlan <vlan>   If specified, enable VLAN filtering with this VLAN ID for the virtual interface.
+--save-params   If specified, will save the passed parameters to %appdata%\WSLAttachSwitch\params.json (will be read from there if no network name is passed when the tool is launched afterwards), alternatively -s as short form
 ```
 
 ## Example
@@ -51,8 +51,8 @@ WSLAttachSwitch.exe "New Virtual Switch"
 WSLAttachSwitch.exe "New Virtual Switch" --mac 00-11-45-14-19-19
 WSLAttachSwitch.exe --mac 00:11:45:14:19:19 "New Virtual Switch"
 WSLAttachSwitch.exe --mac 0011.4514.1919 "New Virtual Switch" --vlan 2
-WSLAttachSwitch.exe "New Virtual Switch" --save-params true
-WSLAttachSwitch.exe #If the tool was previously invoked with --save-params true, then it will re-use the parameters from that invocation
+WSLAttachSwitch.exe "New Virtual Switch" --save-params
+WSLAttachSwitch.exe #If the tool was previously invoked with --save-params, then it will re-use the parameters from that invocation
 ```
 
 ## Notes

--- a/WSLAttachSwitch.csproj
+++ b/WSLAttachSwitch.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PublishAot>true</PublishAot>
-	<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+	  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IlcOptimizationPreference>Size</IlcOptimizationPreference>
     <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>

--- a/WSLAttachSwitch.csproj
+++ b/WSLAttachSwitch.csproj
@@ -9,7 +9,7 @@
 
   <PropertyGroup>
     <PublishAot>true</PublishAot>
-	  <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
+    <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IlcOptimizationPreference>Size</IlcOptimizationPreference>
     <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>

--- a/WSLAttachSwitch.csproj
+++ b/WSLAttachSwitch.csproj
@@ -9,6 +9,7 @@
 
   <PropertyGroup>
     <PublishAot>true</PublishAot>
+	<EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <IlcOptimizationPreference>Size</IlcOptimizationPreference>
     <IlcFoldIdenticalMethodBodies>true</IlcFoldIdenticalMethodBodies>
     <TrimUnusedDependencies>true</TrimUnusedDependencies>
@@ -19,6 +20,7 @@
     <EnableUnsafeUTF7Encoding>false</EnableUnsafeUTF7Encoding>
     <HttpActivityPropagationSupport>false</HttpActivityPropagationSupport>
     <InvariantGlobalization>true</InvariantGlobalization>
+	<EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
   </PropertyGroup>
   <PropertyGroup>
     <ApplicationManifest>WSLAttachSwitch.manifest</ApplicationManifest>

--- a/WSLAttachSwitch.csproj
+++ b/WSLAttachSwitch.csproj
@@ -2,9 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net7.0</TargetFramework>
-    <Version>0.2.0</Version>
-    <Nullable>disable</Nullable>
+    <TargetFramework>net9.0</TargetFramework>
+    <Version>0.3.0</Version>
+    <Nullable>enable</Nullable>
   </PropertyGroup>
 
   <PropertyGroup>
@@ -24,7 +24,7 @@
     <ApplicationManifest>WSLAttachSwitch.manifest</ApplicationManifest>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta5.25306.1" />
   </ItemGroup>
 
 </Project>

--- a/WSLAttachSwitch.sln
+++ b/WSLAttachSwitch.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.14.36212.18 d17.14
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WSLAttachSwitch", "WSLAttachSwitch.csproj", "{AEF6A3C8-9E3B-5EED-4C6E-3688FE9618A3}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{AEF6A3C8-9E3B-5EED-4C6E-3688FE9618A3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{AEF6A3C8-9E3B-5EED-4C6E-3688FE9618A3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{AEF6A3C8-9E3B-5EED-4C6E-3688FE9618A3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{AEF6A3C8-9E3B-5EED-4C6E-3688FE9618A3}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {BD134E39-2C0C-47E4-A043-F022E3B17729}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
This PR updates the dependencies (namely .NET and System.CommandLine) to their current versions.

It furthermore adds the option to save the passed parameters (`--save-params` or in short `-s`), so that in following invocations they do not need to be provided again (will be saved to/read from `%appdata%\WSLAttachSwitch\params.json`).